### PR TITLE
Warn users without pywebview installed

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -2,7 +2,12 @@
 # Python Web Browser, Concept
 # Build not tied to a release
 # experimental-channel
-import webview
+import sys
+try:
+  import webview
+except:
+  print("You need to have Pywebview installed to run FreeCat.")
+  sys.exit()
 import os
 
 engine="pywebview"

--- a/browser.py
+++ b/browser.py
@@ -7,6 +7,10 @@ try:
   import webview
 except:
   print("You need to have Pywebview installed to run FreeCat.")
+  print("On macOS run:")
+  print("pip3 install pywebview")
+  print("On Linux run:")
+  print("pip install pywebview")
   sys.exit()
 import os
 


### PR DESCRIPTION
This also gives instructions on how to install it for macOS and Linux (I don't know what the correct command is on windows)
Edit: I tested with pywebview uninstalled and installed. This code can also be reused if you require the installation of Katana's pip module when you switch to that.