### PR TITLE
Make URL bar show friendly homepage URL

### DIFF
--- a/js/dynamic.js
+++ b/js/dynamic.js
@@ -1,13 +1,22 @@
+window.homepageUrl=window.location.href.replace("index.html","home.html");
 const loadPage = function () {
   let wsite = document.getElementById("searchbox").value;
-  document.getElementById("view").src = wsite;
+  if(wsite=="freecat:homepage") {
+    document.getElementById("view").src=homepageUrl;
+  }
+  else {
+    document.getElementById("view").src = wsite;
+  }
 };
 document.getElementById("load").addEventListener("click", loadPage);
 document.getElementById("searchbox").addEventListener("enter", loadPage);
 let webview = document.getElementById("view");
 let search = document.getElementById("searchbox");
 webview.addEventListener("did-stop-loading", () => {
-  if (document.activeElement !== search) {
+  if (document.activeElement !== search && webview.src!==homepageUrl) {
     search.value = webview.src;
+  }
+  if(webview.src==homepageUrl) {
+    search.value="freecat:homepage";
   }
 });


### PR DESCRIPTION
This is #101 , but based on <a href="https://github.com/JaydenDev/freecat/tree/main">`main`</a>. @JaydenDev I wonder if it'd be possible to make the `freecat:` URL scheme this uses work globally, and maybe add a settings page using this.